### PR TITLE
Case tests

### DIFF
--- a/legal_db/factories.py
+++ b/legal_db/factories.py
@@ -21,7 +21,6 @@ class CaseFactory(DjangoModelFactory):
     country = "US"
     contributor_name = "John Doe"
     contributor_email = "john@test.com"
-    links = factory.SubFactory(LinkFactory)
 
 
 class ScholarshipFactory(DjangoModelFactory):

--- a/legal_db/templates/legal_db/case/index.html
+++ b/legal_db/templates/legal_db/case/index.html
@@ -51,6 +51,8 @@
           </td>
           <td class="number-cell">{{ case.decision_year }}</td>
         </tr>
+      {% empty %}
+        <tr><td class="has-text-centered" colspan="4">No cases are available.</td></tr>
       {% endfor %}
       </tbody>
     </table>

--- a/legal_db/tests.py
+++ b/legal_db/tests.py
@@ -64,7 +64,7 @@ class CaseSubmitViewTests(TestCase):
 
     def test_post_success(self):
         """
-        Test a submitted request with the minimum data required to create a case.
+        Test a submission request with the minimum data required to create a case.
         """
         response = self.client.post(
             self.url,
@@ -91,6 +91,7 @@ class CaseSubmitViewTests(TestCase):
         response = self.client.post(
             self.url,
             data={
+                # Missing contributor name and email and user agreement
                 "name": "Incomplete case form",
                 "form-TOTAL_FORMS": 1,
                 "form-INITIAL_FORMS": 0,
@@ -145,3 +146,47 @@ class ScholarshipDetailViewTests(TestCase):
         scholarship.save()
         response = self.client.get(url)
         self.assertEqual(response.status_code, HTTPStatus.OK)
+
+
+class ScholarshipSubmitViewTests(TestCase):
+    url = reverse("scholarship_submit")
+
+    def test_get(self):
+        """
+        Check if the view of the form is returned correctly.
+        """
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertContains(response, "Scholarship Submission")
+
+    def test_post_success(self):
+        """
+        Test a submission request with the minimum data required to create a
+        scholarship.
+        """
+        response = self.client.post(
+            self.url,
+            data={
+                "contributor_name": "Grace Hopper",
+                "contributor_email": "grace@test.com",
+                "agreement": 1,
+                "url": "www.test.com",
+            },
+        )
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
+        self.assertEqual(response["location"], "/submission-result/")
+
+    def test_post_error(self):
+        """
+        When data send in request is bad (not valid or incomplete) then it should
+        return back to the form view and show the error(s).
+        """
+        response = self.client.post(
+            self.url,
+            data={
+                # Missing contributor name and email, user agreement and link
+                "title": "Incomplete scholarship form",
+            },
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertContains(response, "This field is required")

--- a/legal_db/tests.py
+++ b/legal_db/tests.py
@@ -3,50 +3,34 @@ from http import HTTPStatus
 from django.test import TestCase
 from django.urls import reverse
 
-from .factories import ScholarshipFactory
-from .models import Scholarship
+from .factories import CaseFactory, ScholarshipFactory
+from .models import LegalResource
 
 
-class ScholarshipListViewTests(TestCase):
-    def test_no_scholarship(self):
+class CaseListViewTests(TestCase):
+    url = reverse("case_index")
+
+    def test_no_cases(self):
         """
-        When no scholarship exists, announce and verify that the page still loads.
+        Where there is no case, announce it and verify that the page still loads.
         """
-        response = self.client.get(reverse("scholarship_index"))
+        response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "No scholarships are available.")
+        self.assertContains(response, "No cases are available.")
 
     def test_show_only_published(self):
         """
-        Scholarship list is displayed correctly, only with articles marked with the
-        status 'PUBLISHED'.
+        Case list is displayed correctly, only with cases marked with status
+        'PUBLISHED'.
         """
-        scholarships = ScholarshipFactory.create_batch(3)
-        scholarships[1].status = Scholarship.Status.PUBLISHED
+        CaseFactory.create_batch(3) # Default status is 'Unreviewed'
+        CaseFactory.create_batch(2, status=LegalResource.Status.PUBLISHED)
 
-        response = self.client.get(reverse("scholarship_index"))
+        response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
-        for row in response.context["scholarships"]:
-            self.assertEqual(row.status, Scholarship.Status.PUBLISHED)
-
-
-class ScholarshipDetailViewTests(TestCase):
-    def test_show_only_published(self):
-        """
-        Scholarship details is displayed correctly and only when is marked with the
-        status 'PUBLISHED'. First request ask for a not published article, so details
-        are not shown. Second request is for an published article, therefore is okay
-        to display the article's information.
-        """
-        scholarship = ScholarshipFactory()
-        url = reverse("scholarship_detail", kwargs={"pk": scholarship.id})
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
-
-        scholarship.status = Scholarship.Status.PUBLISHED
-        scholarship.save()
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['cases']), 2)
+        for row in response.context['cases']:
+            self.assertEqual(row.status, LegalResource.Status.PUBLISHED)
 
 
 class CaseSubmitViewTests(TestCase):
@@ -98,3 +82,48 @@ class CaseSubmitViewTests(TestCase):
         )
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertContains(response, "This field is required")
+
+
+class ScholarshipListViewTests(TestCase):
+    url = reverse("scholarship_index")
+
+    def test_no_scholarship(self):
+        """
+        When no scholarship exists, announce it and verify that the page still loads.
+        """
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "No scholarships are available.")
+
+    def test_show_only_published(self):
+        """
+        Scholarship list is displayed correctly, only with articles marked with status
+        'PUBLISHED'.
+        """
+        ScholarshipFactory.create_batch(3) # Default status is 'Unreviewed'
+        ScholarshipFactory.create_batch(2, status=LegalResource.Status.PUBLISHED)
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['scholarships']), 2)
+        for row in response.context["scholarships"]:
+            self.assertEqual(row.status, LegalResource.Status.PUBLISHED)
+
+
+class ScholarshipDetailViewTests(TestCase):
+    def test_show_only_published(self):
+        """
+        Scholarship details is displayed correctly and only when is marked with the
+        status 'PUBLISHED'. First request ask for a not published article, so details
+        are not shown. Second request is for an published article, therefore is okay
+        to display the article's information.
+        """
+        scholarship = ScholarshipFactory()
+        url = reverse("scholarship_detail", kwargs={"pk": scholarship.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+        scholarship.status = LegalResource.Status.PUBLISHED
+        scholarship.save()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)

--- a/legal_db/views.py
+++ b/legal_db/views.py
@@ -34,8 +34,8 @@ class CaseListView(ListView):
 
 class CaseDetailView(DetailView):
     template_name = "legal_db/case/detail.html"
-    model = Case
     context_object_name = "case"
+    queryset = Case.objects.filter(status=Case.Status.PUBLISHED)
 
     def get_object(self):
         obj = super().get_object()


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
Increase test coverage.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
